### PR TITLE
Fixing linker problems

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -14,6 +14,6 @@
 // Global variables and defines.
 #define LED_PIN (3)
 // (Core system clock speed; initial value depends on the chip.)
-volatile uint32_t core_clock_hz;
+extern volatile uint32_t core_clock_hz;
 
-#endif
+#endif // _VVC_GLOBAL_H

--- a/src/main.c
+++ b/src/main.c
@@ -4,6 +4,8 @@
  * Main program.
  */
 int main(void) {
+  volatile uint32_t core_clock_hz;
+
   // Initial clock setup.
   #ifdef VVC_F0
     // Reset the Flash 'Access Control Register', and

--- a/src/peripherals.c
+++ b/src/peripherals.c
@@ -8,6 +8,8 @@
  * It should trigger every N milliseconds.
  */
 void start_timer(TIM_TypeDef *TIMx, uint16_t ms) {
+  volatile uint32_t core_clock_hz;
+
   // Start by making sure the timer's 'counter' is off.
   TIMx->CR1 &= ~(TIM_CR1_CEN);
   // Next, reset the peripheral. (This is where a HAL can help)


### PR DESCRIPTION
When I attempted to build this code with `arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10-2020-q4-major) 10.2.1 20201103 (release)`, I got linker errors about `core_clock_hz` being defined in multiple locations.  This change eliminates those errors by declaring the variable as an `extern` in `global.h`, and then declaring it in `main.c` and `peripherals.c`.  With these changes, I'm able to build the code, and it runs properly on my L031K6 Nucleo board.